### PR TITLE
Ignore links in comments *TEMP BANDAID*

### DIFF
--- a/AFSCbot.py
+++ b/AFSCbot.py
@@ -134,12 +134,13 @@ while True:
             else:
                 formattedComment = rAirForceComments.body
                 formattedComment = formattedComment.upper()
-				# Sub out all HTML tags, should remove links from anchor tags
-				# that could contain AFSCs by chance.
-				re.sub('<[^<]+?>', '', formattedComment)
-				# Sub out all remaining links explicitly in the comment that match http(s)
-				re.sub('http(s?):\/\/[\S]*[\s]?', '', formattedComment)
-				
+
+                # Sub out all remaining links explicitly in the comment that match http(s)
+                formattedComment =  re.sub('http(s?):\/\/[\S]*[\s]?', '', formattedComment)
+
+                # Sub out all HTML tags, should remove links from anchor tags
+                # that could contain AFSCs by chance.
+                formattedComment = re.sub('<[^<]+?>', '', formattedComment)
 
                 commentList = ""
                 matchList = []

--- a/AFSCbot.py
+++ b/AFSCbot.py
@@ -134,13 +134,15 @@ while True:
             else:
                 formattedComment = rAirForceComments.body
                 formattedComment = formattedComment.upper()
-
-                # Sub out all remaining links explicitly in the comment that match http(s)
-                formattedComment =  re.sub('http(s?):\/\/[\S]*[\s]?', '', formattedComment)
-
+                
                 # Sub out all HTML tags, should remove links from anchor tags
                 # that could contain AFSCs by chance.
                 formattedComment = re.sub('<[^<]+?>', '', formattedComment)
+                
+                # Sub out all remaining links explicitly in the comment that match http(s)
+                formattedComment = re.sub(r'http(s?)://[\S]*[\s]?', '', formattedComment)
+
+
 
                 commentList = ""
                 matchList = []

--- a/AFSCbot.py
+++ b/AFSCbot.py
@@ -7,6 +7,7 @@ import time
 import os
 import sys
 import csv
+import re
 # Initialize a logging object and have some examples below from the Python
 # Doc page
 logging.basicConfig(filename='AFSCbot.log', level=logging.INFO)
@@ -133,6 +134,12 @@ while True:
             else:
                 formattedComment = rAirForceComments.body
                 formattedComment = formattedComment.upper()
+				# Sub out all HTML tags, should remove links from anchor tags
+				# that could contain AFSCs by chance.
+				re.sub('<[^<]+?>', '', formattedComment)
+				# Sub out all remaining links explicitly in the comment that match http(s)
+				re.sub('http(s?):\/\/[\S]*[\s]?', '', formattedComment)
+				
 
                 commentList = ""
                 matchList = []


### PR DESCRIPTION
Added 2 regular expressions to remove all HTML tags from the comment
(line 139) and to remove any links that might still remain due to being
the text of the hyperlink (line 141).

These changes should keep the bot from responding to 'AFSCs' that just
happen to be part of a URL as opposed to someone actually referencing an
AFSC.