### PR TITLE
Fixed officer bug

### DIFF
--- a/AFSCbot/main.py
+++ b/AFSCbot/main.py
@@ -25,12 +25,16 @@ def main():
     conn, dbCommentRecord = setup_database()
 
     # load all the AFSCs and prefixes into dictionaries
-    full_afsc_dict = get_AFSCs()
-    full_afsc_dict = get_afsc_links(reddit, full_afsc_dict)
-    prefix_dict = get_prefixes()
+    try:
+        full_afsc_dict = get_AFSCs()
+        full_afsc_dict = get_afsc_links(reddit, full_afsc_dict)
+        prefix_dict = get_prefixes()
+    finally:
+        close_pid()
 
-    # subreddit instance of /r/AirForce.
-    rAirForce = reddit.subreddit(SUBREDDIT)
+        # subreddit instance of /r/AirForce.
+        rAirForce = reddit.subreddit(SUBREDDIT)
+
 
     print_and_log("Starting processing loop for subreddit: " + SUBREDDIT)
     comments_seen = 0

--- a/AFSCbot/process_comment.py
+++ b/AFSCbot/process_comment.py
@@ -150,18 +150,14 @@ def process_enlisted(comment_text, enlisted_individual_matches, enlisted_dict,
     return comment_text
 
 
-def process_officer(comment_text, officer_individual_matches, matchList,
-                    officer_dict, prefix_dict):
+def process_officer(comment_text, officer_individual_matches, officer_dict,
+                    prefix_dict):
 
     whole_match = officer_individual_matches.group(1)
     prefix = officer_individual_matches.group(2)
     afsc = officer_individual_matches.group(3)
     skill_level = officer_individual_matches.group(4)
     suffix = officer_individual_matches.group(5)
-
-    # if already commented, dont add it again
-    if whole_match in matchList:
-        return comment_text
 
     print("Whole match: " + whole_match)
     if prefix:
@@ -182,8 +178,13 @@ def process_officer(comment_text, officer_individual_matches, matchList,
         print_and_log("from whole_match: {}, found {} in officer AFSCs"
                       .format(whole_match, tempAFSC))
 
-        matchList.append(whole_match)
-        comment_line += whole_match + " = "
+        # build whole AFSC only if prefix and suffix exist
+        if prefix in prefix_dict["officer"].keys():
+            comment_line += prefix
+        comment_line += afsc
+        if suffix in officer_dict[tempAFSC]["shreds"].keys():
+            comment_line += suffix
+        comment_line += " = "
 
         # Is there a prefix? If so, add it
         if prefix:
@@ -197,6 +198,8 @@ def process_officer(comment_text, officer_individual_matches, matchList,
 
         # add job title
         comment_line += officer_dict[tempAFSC]["job_title"]
+
+        # skill level printout ignored for officers
 
         # Is there a suffix? If so, add it
         if suffix:

--- a/AFSCbot/process_comment.py
+++ b/AFSCbot/process_comment.py
@@ -95,9 +95,12 @@ def process_comment(comment_text, matches, afsc_dict, prefix_dict):
         # replaces the skill level with an X
         tempAFSC = afsc[:3] + "X" + afsc[4:]
     else:
-        # if skill level doesnt exist, add X to tempAFSC
-        if skill_level:
+        # standardize officer tempAFSC to be 12SX
+        if skill_level == "X":
             tempAFSC = afsc
+        elif skill_level.isnumeric():
+            afsc = afsc[:-1] + "X"  # skill level printed as X
+            tempAFSC = afsc[:-1] + "X"
         else:
             tempAFSC = afsc + 'X'
 

--- a/AFSCbot/process_comment.py
+++ b/AFSCbot/process_comment.py
@@ -23,21 +23,23 @@ def generate_reply(rAirForceComment, full_afsc_dict, prefix_dict):
     matched_comments_officer = get_officer_regex_matches(formatted_comment)
 
     # prepare dicts for enlisted and officer AFSCs
-    enlisted_dict = full_afsc_dict["enlisted"]
-    officer_dict = full_afsc_dict["officer"]
+    enlisted_afsc_dict = full_afsc_dict["enlisted"]
+    enlisted_prefix_dict = prefix_dict["enlisted"]
+    officer_afsc_dict = full_afsc_dict["officer"]
+    officer_prefix_dict = prefix_dict["officer"]
 
     match_list = []
     comment_text = []
 
     # process all enlisted
-    for enlisted_individual_matches in matched_comments_enlisted:
-        comment_text = process_enlisted(comment_text, enlisted_individual_matches,
-                                        enlisted_dict, prefix_dict)
+    for matches in matched_comments_enlisted:
+        comment_text = process_comment(comment_text, matches,
+                                        enlisted_afsc_dict, enlisted_prefix_dict)
 
     # process all officer
-    for officer_individual_matches in matched_comments_officer:
-        comment_text = process_officer(comment_text, officer_individual_matches,
-                                       officer_dict, prefix_dict)
+    for matches in matched_comments_officer:
+        comment_text = process_comment(comment_text, matches,
+                                       officer_afsc_dict, officer_prefix_dict)
 
     # log that comment was prepared
     comment_info_text = ("Preparing to reply: {} by: {}. Comment ID: {}".format(
@@ -69,14 +71,15 @@ def send_reply(comment_text, rAirForceComment):
     print_and_log("Sent reply...")
 
 
-def process_enlisted(comment_text, enlisted_individual_matches, enlisted_dict,
-                     prefix_dict):
+def process_comment(comment_text, matches, afsc_dict, prefix_dict):
 
-    whole_match = enlisted_individual_matches.group(1).upper()
-    prefix = enlisted_individual_matches.group(2).upper()
-    afsc = enlisted_individual_matches.group(3).upper()
-    skill_level = enlisted_individual_matches.group(4).upper()
-    suffix = enlisted_individual_matches.group(5).upper()
+    whole_match = matches.group(1).upper()
+    prefix = matches.group(2).upper()
+    afsc = matches.group(3).upper()
+    skill_level = matches.group(4).upper()
+    suffix = matches.group(5).upper()
+
+    dict_type = afsc_dict["dict_type"]
 
     print("Whole match: " + whole_match)
     if prefix:
@@ -87,45 +90,55 @@ def process_enlisted(comment_text, enlisted_individual_matches, enlisted_dict,
     if suffix:
         print("Suffix: " + suffix)
 
-    # replaces the skill level with an X
-    tempAFSC = afsc[:3] + "X" + afsc[4:]
+    # handle skill levels
+    if dict_type == "enlisted":
+        # replaces the skill level with an X
+        tempAFSC = afsc[:3] + "X" + afsc[4:]
+    else:
+        # if skill level doesnt exist, add X to tempAFSC
+        if skill_level:
+            tempAFSC = afsc
+        else:
+            tempAFSC = afsc + 'X'
 
     comment_line = ""
     # if comment base AFSC is in dict of base AFSC's
-    if tempAFSC in enlisted_dict.keys():
-        print_and_log("from whole_match: {}, found {} in enlisted AFSCs"
-                      .format(whole_match, tempAFSC))
+    if tempAFSC in afsc_dict.keys():
+        print_and_log("from whole_match: {}, found {} in {} AFSCs"
+                      .format(whole_match, tempAFSC, dict_type))
 
         # build whole AFSC only if prefix and suffix exist
-        if prefix in prefix_dict["enlisted"].keys():
+        if prefix in prefix_dict.keys():
             comment_line += prefix
         comment_line += afsc
-        if suffix in enlisted_dict[tempAFSC]["shreds"].keys():
+        if suffix in afsc_dict[tempAFSC]["shreds"].keys():
             comment_line += suffix
         comment_line += " = "
 
         # Is there a prefix? If so, add its title
         if prefix:
-            if prefix in prefix_dict["enlisted"].keys():
-                comment_line += prefix_dict["enlisted"][prefix] + " "
-                print_and_log("found prefix {} in enlisted dict"
-                              .format(prefix))
+            if prefix in prefix_dict.keys():
+                comment_line += prefix_dict[prefix] + " "
+                print_and_log("found prefix {} in {} dict"
+                              .format(prefix, dict_type))
             else:
-                print_and_log("could not fimd prefix {} in enlisted dict"
-                              .format(prefix))
+                print_and_log("could not find prefix {} in {} dict"
+                              .format(prefix, dict_type))
 
         # add job title
-        comment_line += enlisted_dict[tempAFSC]["job_title"]
+        comment_line += afsc_dict[tempAFSC]["job_title"]
 
-        # if skill level given is not X or O, describe skill level given
-        if skill_level != 'X' and skill_level != '0':
-            comment_line += " " + \
-            ENLISTED_SKILL_LEVELS[int(skill_level) - 1]
+        # add skill level, officer skill level is ignored
+        if dict_type == "enlisted":
+            # if skill level given is not X or O, describe skill level given
+            if skill_level != 'X' and skill_level != '0':
+                comment_line += " " + \
+                ENLISTED_SKILL_LEVELS[int(skill_level) - 1]
 
         # Is there a suffix? If so, add its title
         if suffix:
-            if suffix in enlisted_dict[tempAFSC]["shreds"].keys():
-                comment_line += ", " + enlisted_dict[tempAFSC]["shreds"][suffix]
+            if suffix in afsc_dict[tempAFSC]["shreds"].keys():
+                comment_line += ", " + afsc_dict[tempAFSC]["shreds"][suffix]
                 print_and_log("found suffix {} under {}"
                           .format(suffix, tempAFSC))
             else:
@@ -133,7 +146,7 @@ def process_enlisted(comment_text, enlisted_individual_matches, enlisted_dict,
                               .format(suffix, tempAFSC))
 
         try:
-            afsc_link = enlisted_dict[tempAFSC]["link"]
+            afsc_link = afsc_dict[tempAFSC]["link"]
             comment_line += "\n\n Look they have a [Wiki Page]({})"\
                 .format(afsc_link)
             print_and_log("found a link for {} at {}"
@@ -145,76 +158,7 @@ def process_enlisted(comment_text, enlisted_individual_matches, enlisted_dict,
         if comment_line not in comment_text:
             comment_text.append(comment_line)
     else:
-        print_and_log("Did not find {} in enlisted AFSCs".format(tempAFSC))
-    print("-------")
-    return comment_text
-
-
-def process_officer(comment_text, officer_individual_matches, officer_dict,
-                    prefix_dict):
-
-    whole_match = officer_individual_matches.group(1)
-    prefix = officer_individual_matches.group(2)
-    afsc = officer_individual_matches.group(3)
-    skill_level = officer_individual_matches.group(4)
-    suffix = officer_individual_matches.group(5)
-
-    print("Whole match: " + whole_match)
-    if prefix:
-        print("Prefix: " + prefix)
-    print("AFSC: " + afsc)
-    if skill_level:
-        print("Skill Level: " + skill_level)
-    if suffix:
-        print("Suffix: " + suffix)
-
-    if skill_level:
-        tempAFSC = afsc
-    else:
-        tempAFSC = afsc + 'X'
-
-    comment_line = ""
-    if tempAFSC in officer_dict.keys():
-        print_and_log("from whole_match: {}, found {} in officer AFSCs"
-                      .format(whole_match, tempAFSC))
-
-        # build whole AFSC only if prefix and suffix exist
-        if prefix in prefix_dict["officer"].keys():
-            comment_line += prefix
-        comment_line += afsc
-        if suffix in officer_dict[tempAFSC]["shreds"].keys():
-            comment_line += suffix
-        comment_line += " = "
-
-        # Is there a prefix? If so, add it
-        if prefix:
-            if prefix in prefix_dict["officer"].keys():
-                comment_line += prefix_dict["officer"][prefix] + " "
-                print_and_log("found prefix {} in officer dict"
-                              .format(prefix))
-            else:
-                print_and_log("could not fimd prefix {} in officer dict"
-                              .format(prefix))
-
-        # add job title
-        comment_line += officer_dict[tempAFSC]["job_title"]
-
-        # skill level printout ignored for officers
-
-        # Is there a suffix? If so, add it
-        if suffix:
-            if suffix in officer_dict[tempAFSC]["shreds"].keys():
-                comment_line += ", " + officer_dict[tempAFSC]["shreds"][suffix]
-                print_and_log("found suffix {} under {}"
-                              .format(suffix, tempAFSC))
-            else:
-                print_and_log("could not find suffix {} under {}"
-                              .format(suffix, tempAFSC))
-
-        if comment_line not in comment_text:
-            comment_text.append(comment_line)
-    else:
-        print_and_log("Did not find {} in officer AFSCs".format(tempAFSC))
+        print_and_log("Did not find {} in {} AFSCs".format(tempAFSC, dict_type))
     print("-------")
     return comment_text
 

--- a/AFSCbot/read_csv_files.py
+++ b/AFSCbot/read_csv_files.py
@@ -8,8 +8,8 @@ CSV_FOLDER = os.getcwd() + "\csv_files\\"
 
 
 def get_AFSCs():
-    enlisted_dict = {}
-    officer_dict = {}
+    enlisted_dict = {"dict_type": "enlisted"}
+    officer_dict = {"dict_type": "officer"}
     full_afsc_dict = {"enlisted": enlisted_dict,
                       "officer": officer_dict}
 

--- a/AFSCbot/read_csv_files.py
+++ b/AFSCbot/read_csv_files.py
@@ -68,6 +68,7 @@ def get_AFSCs():
 def get_prefixes():
     prefix_dict = {"enlisted": {},
                    "officer": {}}
+
     with open(CSV_FOLDER + 'EnlistedPrefixes.csv', newline='') as f:
         reader = csv.reader(f, delimiter=',')
         for row in reader:
@@ -90,12 +91,13 @@ def get_afsc_links(reddit, full_afsc_dict):
     wiki_soup = BeautifulSoup(wiki_page.content_html, "html.parser")
     links = wiki_soup.find_all("a")
 
+    # currently all wiki AFSC are enlisted
     for link in links:
         # not all links have /r/AirForce/wiki/jobs so this is more generalized
         # using only /r/AirForce/ wiki links
         if "www.reddit.com/r/AirForce/wiki/" in link["href"]:
             AFSC_code = link["href"].split("/")[-1].upper()
-            base_afsc = AFSC_code[:5]
+            base_afsc = AFSC_code[:5]  # shaves off any prefixes
             if base_afsc in full_afsc_dict["enlisted"].keys():
                 full_afsc_dict["enlisted"][base_afsc]["link"] = link["href"]
     return full_afsc_dict

--- a/AFSCbot/test_process_comment.py
+++ b/AFSCbot/test_process_comment.py
@@ -1,5 +1,6 @@
 import unittest
 from process_comment import get_enlisted_regex_matches, get_officer_regex_matches, break_up_regex
+from read_csv_files import get_AFSCs, get_prefixes, get_afsc_links
 
 #####################
 """ Unit tests """
@@ -393,5 +394,39 @@ class OfficerRegexMatch(unittest.TestCase):
         matches = get_officer_regex_matches(comment)
         str_matches = break_up_regex(matches)
         self.assertEqual(len(str_matches), 0)
+
+
+"""
+Some of these tests may fail because the csv files update.
+In that case, double check if any titles have changed.
+"""
+
+'''
+global test_prefix_dict
+global test_afsc_dict
+
+test_afsc_dict = get_AFSCs()
+test_afsc_dict = get_afsc_links(test_afsc_dict)
+test_prefix_dict = get_prefixes()
+'''
+
+class OfficerProcessComment(unittest.TestCase):
+
+    def test_setup_prefix_dict(self):
+        print(test_prefix_dict)
+
+    def test_normal_afsc(self):
+        print(self._prefix_dict)
+        comment = "12HX"
+        matches = get_officer_regex_matches(comment)
+        str_matches = break_up_regex(matches)
+        self.assertEqual(len(str_matches), 1)
+        self.assertEqual(str_matches[0]["whole_match"], "12HX")
+        self.assertEqual(str_matches[0]["prefix"], "")
+        self.assertEqual(str_matches[0]["afsc"], "12HX")
+        self.assertEqual(str_matches[0]["skill_level"], "X")
+        self.assertEqual(str_matches[0]["suffix"], "")
+
+
 
 unittest.main(module=__name__)


### PR DESCRIPTION
resolves #12 . Now works for officers like normal. I combined process_enlisted and process_officer into one function with a few if statements, since they were 95% the same anyways. 

Also dif bug from 13S1E where it would try to look up 13S1 and woudn't find anything. Now it also prints out 13SXE even if you type 13S1E. If thats not what we want I can change it.